### PR TITLE
Cache PyGeoAPI lookups and add confirm modal

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -42,6 +42,6 @@ jobs:
       - name: Install Node.js dependencies
         run: npm install
       - name: Check CSS rules via Stylelint
-        run: npx stylelint "datenwerft/**/*.css" "datenmanagement/**/*.css"
+        run: npx stylelint "angebotsdb/**/*.css" "datenwerft/**/*.css" "datenmanagement/**/*.css"
       - name: Check JavaScript rules via ESLint
         run: npx eslint "datenwerft/static" "angebotsdb/static" "antragsmanagement/static" "bemas/static" "datenmanagement/static"

--- a/angebotsdb/fields.py
+++ b/angebotsdb/fields.py
@@ -1,18 +1,28 @@
+import hashlib
 import logging
 
-import requests
+import httpx
+from django.core.cache import cache
 from django.forms import MultipleChoiceField, widgets
 
 logger = logging.getLogger(__name__)
 
+_PYGEOAPI_CACHE_TTL = 600  # 10 Minuten
 
-def resolve_pygeoapi_uris(uris, endpoint, params, label_property):
+
+def _fetch_pygeoapi_label_map(endpoint, params_tuple, label_property):
   """
-  Löst eine Liste von PyGeoAPI-URIs zu lesbaren Labels auf.
-  Gibt bei Fehler die rohen URIs zurück (Fallback).
+  Lädt alle Features vom PyGeoAPI-Endpunkt und gibt ein URI→Label-Dict zurück.
+  Gecacht für :data:`_PYGEOAPI_CACHE_TTL` Sekunden über Djangos Cache-Framework.
   """
+  cache_key = (
+    'pygeoapi_' + hashlib.md5(f'{endpoint}|{params_tuple}|{label_property}'.encode()).hexdigest()
+  )
+  cached = cache.get(cache_key)
+  if cached is not None:
+    return cached
   try:
-    response = requests.get(endpoint, params=params, timeout=10)
+    response = httpx.get(endpoint, params=dict(params_tuple), timeout=10)
     response.raise_for_status()
     data = response.json()
     base_url = endpoint.rstrip('/')
@@ -28,10 +38,24 @@ def resolve_pygeoapi_uris(uris, endpoint, params, label_property):
         uri = f'{base_url}/{feature_id}'
       if uri and label:
         uri_to_label[uri] = label
-    return [uri_to_label.get(u, u) for u in uris]
-  except requests.RequestException as e:
-    logger.error('PyGeoAPI resolve failed for %s: %s', endpoint, e)
-    return list(uris)
+    cache.set(cache_key, uri_to_label, timeout=_PYGEOAPI_CACHE_TTL)
+    return uri_to_label
+  except httpx.HTTPError as e:
+    logger.error('PyGeoAPI fetch failed for %s: %s', endpoint, e)
+    return {}
+
+
+def resolve_pygeoapi_uris(uris, endpoint, params, label_property):
+  """
+  Löst eine Liste von PyGeoAPI-URIs zu lesbaren Labels auf.
+  Gibt bei Fehler die rohen URIs zurück (Fallback).
+  """
+  label_map = _fetch_pygeoapi_label_map(
+    endpoint,
+    tuple(sorted(params.items())),
+    label_property,
+  )
+  return [label_map.get(u, u) for u in uris]
 
 
 class PyGeoAPIMultipleChoiceField(MultipleChoiceField):
@@ -73,26 +97,11 @@ class PyGeoAPIMultipleChoiceField(MultipleChoiceField):
     super().__init__(choices=choices, **kwargs)
 
   def _fetch_choices(self, endpoint, params, label_property):
-    try:
-      response = requests.get(endpoint, params=params, timeout=10)
-      response.raise_for_status()
-      data = response.json()
-      base_url = endpoint.rstrip('/')
-      choices = []
-      for feature in data.get('features', []):
-        label = feature.get('properties', {}).get(label_property, '')
-        feature_id = feature.get('id')
-        # Prefer self link if present, otherwise construct URI from endpoint + id
-        uri = next(
-          (link['href'] for link in feature.get('links', []) if link.get('rel') == 'self'),
-          None,
-        )
-        if uri is None and feature_id is not None:
-          uri = f'{base_url}/{feature_id}'
-        if uri and label:
-          choices.append((uri, label))
-      choices.sort(key=lambda x: x[1])
-      return choices
-    except requests.RequestException as e:
-      logger.error('PyGeoAPI fetch failed for %s: %s', endpoint, e)
-      return []
+    label_map = _fetch_pygeoapi_label_map(
+      endpoint,
+      tuple(sorted(params.items())),
+      label_property,
+    )
+    choices = list(label_map.items())
+    choices.sort(key=lambda x: x[1])
+    return choices

--- a/angebotsdb/templates/angebotsdb/form.html
+++ b/angebotsdb/templates/angebotsdb/form.html
@@ -194,6 +194,29 @@
                         <span class="input-group-text">#</span>
                         {{ field }}
                       </div>
+                    {% elif field.name == 'logo' %}
+                      {% if form.instance.logo %}
+                        <div class="d-flex align-items-center mb-2" id="logo-preview-row">
+                          <a href="{{ form.instance.logo.url }}" target="_blank" class="me-2 flex-shrink-0">
+                            <img src="{{ form.instance.logo.url }}" alt="Logo"
+                                 width="60" height="60" class="rounded object-fit-cover">
+                          </a>
+                          <span class="me-auto">{{ form.instance.logo.name|cut:"angebotsdb/hosts/" }}</span>
+                          {% if user_can_save and not readonly %}
+                            <input type="hidden" name="{{ field.html_name }}-clear" id="logo-clear-input" value="">
+                            <button type="button" class="btn btn-sm btn-outline-danger ms-2"
+                                    id="logo-delete-btn">
+                              <i class="fa-solid fa-xmark"></i>
+                            </button>
+                          {% endif %}
+                        </div>
+                      {% endif %}
+                      {% if user_can_save and not readonly %}
+                        <div class="input-group">
+                          <input type="file" name="{{ field.html_name }}" class="form-control"
+                                 id="{{ field.id_for_label }}" accept="image/*">
+                        </div>
+                      {% endif %}
                     {% elif field.type == 'file' %}
                       <div class="input-group">
                         <label class="input-group-text" for="{{ field.id }}">Upload</label>
@@ -627,23 +650,43 @@
             });
           }
 
+          // Logo löschen
+          var logoDeleteBtn = document.getElementById('logo-delete-btn');
+          if (logoDeleteBtn) {
+            logoDeleteBtn.addEventListener('click', function() {
+              showConfirmModal(
+                'Logo löschen',
+                'Soll das Logo wirklich gelöscht werden?',
+                function() {
+                  document.getElementById('logo-clear-input').value = 'on';
+                  document.getElementById('logo-preview-row').remove();
+                }
+              );
+            });
+          }
+
           // Bestehende Bilder per AJAX löschen
           document.querySelectorAll('.delete-image-btn').forEach(function(btn) {
             btn.addEventListener('click', function() {
               const imageId = this.dataset.imageId;
-              if (!confirm('Bild wirklich löschen?')) return;
-              fetch('/angebotsdb/service-image/' + imageId + '/delete/', {
-                method: 'POST',
-                headers: {
-                  'X-CSRFToken': document.querySelector('[name=csrfmiddlewaretoken]').value,
-                  'X-Requested-With': 'XMLHttpRequest',
-                },
-              }).then(function(r) { return r.json(); }).then(function(data) {
-                if (data.success) {
-                  const row = document.querySelector('.existing-image-row[data-image-id="' + imageId + '"]');
-                  if (row) row.remove();
+              showConfirmModal(
+                'Bild löschen',
+                'Soll dieses Bild wirklich gelöscht werden?',
+                function() {
+                  fetch('/angebotsdb/service-image/' + imageId + '/delete/', {
+                    method: 'POST',
+                    headers: {
+                      'X-CSRFToken': document.querySelector('[name=csrfmiddlewaretoken]').value,
+                      'X-Requested-With': 'XMLHttpRequest',
+                    },
+                  }).then(function(r) { return r.json(); }).then(function(data) {
+                    if (data.success) {
+                      const row = document.querySelector('.existing-image-row[data-image-id="' + imageId + '"]');
+                      if (row) row.remove();
+                    }
+                  });
                 }
-              });
+              );
             });
           });
         });
@@ -656,6 +699,6 @@
   </div>
   <script src="{% static 'js/form.js' %}"></script>
 
-  <!-- Löschen-Modal -->
+  {% include "angebotsdb/includes/confirm_modal.html" %}
   {% include "angebotsdb/includes/delete_modal.html" %}
 {% endblock %}

--- a/angebotsdb/templates/angebotsdb/includes/confirm_modal.html
+++ b/angebotsdb/templates/angebotsdb/includes/confirm_modal.html
@@ -1,0 +1,51 @@
+<!-- Wiederverwendbares Bestätigungs-Modal -->
+<div class="modal fade" id="confirmModal" tabindex="-1"
+     aria-labelledby="confirmModalLabel" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="confirmModalLabel">
+          <i class="fa-solid fa-exclamation-triangle me-2"></i>
+          <span id="confirmModalTitle"></span>
+        </h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal"
+                aria-label="Schließen"></button>
+      </div>
+      <div class="modal-body" id="confirmModalBody"></div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-danger" id="confirmModalBtn">
+          <i class="fa-solid fa-trash me-1"></i>Ja, löschen
+        </button>
+        <button type="button" class="btn btn-outline-secondary"
+                data-bs-dismiss="modal">
+          <i class="fa-solid fa-times me-1"></i>Abbrechen
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+  /**
+   * Zeigt das generische Bestätigungs-Modal.
+   * @param {string} title  - Titel des Modals
+   * @param {string} body   - Bestätigungstext im Modal-Body
+   * @param {Function} onConfirm - Callback, der bei Bestätigung aufgerufen wird
+   */
+  function showConfirmModal(title, body, onConfirm) {
+    document.getElementById('confirmModalTitle').textContent = title;
+    document.getElementById('confirmModalBody').textContent = body;
+
+    var btn = document.getElementById('confirmModalBtn');
+    // Alten Handler entfernen, damit er nicht mehrfach feuert
+    var newBtn = btn.cloneNode(true);
+    btn.parentNode.replaceChild(newBtn, btn);
+    newBtn.addEventListener('click', function() {
+      bootstrap.Modal.getInstance(document.getElementById('confirmModal')).hide();
+      onConfirm();
+    });
+
+    var modal = new bootstrap.Modal(document.getElementById('confirmModal'));
+    modal.show();
+  }
+</script>

--- a/angebotsdb/templates/angebotsdb/includes/delete_modal.html
+++ b/angebotsdb/templates/angebotsdb/includes/delete_modal.html
@@ -92,7 +92,10 @@
             });
           }
           
-          detailRow.innerHTML = `<strong>${key}:</strong> ${displayValue}`;
+          const strong = document.createElement('strong');
+          strong.textContent = `${key}:`;
+          detailRow.appendChild(strong);
+          detailRow.appendChild(document.createTextNode(` ${String(displayValue)}`));
           detailsContainer.appendChild(detailRow);
         }
       }
@@ -129,7 +132,10 @@
           
           // Zur Listenansicht weiterleiten
           const listUrl = deleteForm.getAttribute('data-list-url');
-          window.location.href = listUrl;
+          const safeUrl = new URL(listUrl, window.location.origin);
+          if (safeUrl.origin === window.location.origin) {
+            window.location.href = safeUrl.href;
+          }
         } else {
           throw new Error('Fehler beim Löschen');
         }

--- a/angebotsdb/templates/angebotsdb/index.html
+++ b/angebotsdb/templates/angebotsdb/index.html
@@ -154,6 +154,25 @@
         </div>
       </div>
 
+      <!-- Feedback -->
+      <div id="grid-item-feedback" class="grid-item">
+        <div class="card bg-info-subtle border-info text-center h-100">
+          <div class="card-body position-absolute top-50 start-50 translate-middle w-100">
+            <h3><i class="fa-fw fa-solid fa-comments me-2"></i>Feedback</h3>
+            <div class="row row-cols-1 row-cols-md-1 g-2 mt-4">
+              <div class="col d-grid">
+                <a href="https://nextcloud.sv.rostock.de/apps/forms/s/kL42wRmXTmNbRZfZTQgLmFpR"
+                   target="_blank"
+                   rel="noopener noreferrer"
+                   class="btn btn-info">
+                  <i class="fa-fw fa-solid fa-arrow-up-right-from-square me-2"></i>Zum Formular
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
       <!-- Fehlermeldungsprotokoll -->
       <div id="grid-item-fehlermeldung" class="grid-item">
         <div class="card bg-danger-subtle border-danger text-center h-100">

--- a/angebotsdb/templatetags/angebotsdb_tags.py
+++ b/angebotsdb/templatetags/angebotsdb_tags.py
@@ -4,6 +4,8 @@ from django import template
 from django.core.serializers.json import DjangoJSONEncoder
 from django.urls import reverse
 
+from ..fields import _fetch_pygeoapi_label_map
+
 register = template.Library()
 
 
@@ -43,10 +45,20 @@ def to_json(obj):
         )
 
       # Handle different field types
+      pygeoapi_fields = getattr(obj.__class__, 'PYGEOAPI_FIELDS', {})
       if field_value is None:
         data[display_name] = None
       elif hasattr(field_value, 'isoformat'):  # DateTime, Date, Time fields
         data[display_name] = field_value.isoformat()
+      elif field_name in pygeoapi_fields and isinstance(field_value, list) and field_value:
+        config = pygeoapi_fields[field_name]
+        label_map = _fetch_pygeoapi_label_map(
+          config['endpoint'],
+          tuple(sorted(config.get('params', {}).items())),
+          config['label_property'],
+        )
+        labels = [label_map.get(uri, uri) for uri in field_value]
+        data[display_name] = ', '.join(labels)
       else:
         data[display_name] = str(field_value)
 

--- a/angebotsdb/tests/views/tests_services.py
+++ b/angebotsdb/tests/views/tests_services.py
@@ -19,7 +19,7 @@ from ..constant_vars import (
 from ..functions import login_as_admin, login_as_provider, login_no_role
 
 HTML = 'text/html; charset=utf-8'
-PYGEOAPI_PATCH = 'angebotsdb.fields.requests.get'
+PYGEOAPI_PATCH = 'angebotsdb.fields.httpx.get'
 
 
 def _base_service_form_data(topic_pk, law_pk):

--- a/angebotsdb/views/forms.py
+++ b/angebotsdb/views/forms.py
@@ -1,4 +1,5 @@
 import json
+import logging
 
 from django.conf import settings
 from django.contrib.auth.models import User
@@ -11,6 +12,8 @@ from django.shortcuts import redirect
 from django.urls import reverse, reverse_lazy
 from django.views import View
 from django.views.generic.edit import CreateView, DeleteView, UpdateView
+
+logger = logging.getLogger(__name__)
 
 from ..constants_vars import ADMIN_GROUP, USERS_GROUP
 from ..fields import PyGeoAPIMultipleChoiceField
@@ -843,11 +846,12 @@ class GenericDeleteView(DeleteView):
           }
         )
       except PermissionDenied as e:
-        return JsonResponse({'success': False, 'message': str(e)}, status=403)
+        logger.warning(f'Permission denied when deleting object: {e}')
+        return JsonResponse({'success': False, 'message': 'Keine Berechtigung.'}, status=403)
       except Exception as e:
-        # Fehlermeldung zurückgeben
+        logger.error(f'Error deleting object: {e}')
         return JsonResponse(
-          {'success': False, 'message': f'Fehler beim Löschen: {str(e)}'}, status=400
+          {'success': False, 'message': 'Ein interner Fehler ist aufgetreten.'}, status=400
         )
     else:
       return super().post(request, *args, **kwargs)

--- a/angebotsdb/views/forms.py
+++ b/angebotsdb/views/forms.py
@@ -13,8 +13,6 @@ from django.urls import reverse, reverse_lazy
 from django.views import View
 from django.views.generic.edit import CreateView, DeleteView, UpdateView
 
-logger = logging.getLogger(__name__)
-
 from ..constants_vars import ADMIN_GROUP, USERS_GROUP
 from ..fields import PyGeoAPIMultipleChoiceField
 from ..models.base import Law, Provider, ReviewTask, Tag, TargetGroup, Topic, UserProfile
@@ -32,6 +30,8 @@ from ..utils import (
   is_angebotsdb_user,
 )
 from .functions import add_permission_context_elements
+
+logger = logging.getLogger(__name__)
 
 
 def _set_geometry_from_request(request, instance):

--- a/angebotsdb/views/indexView.py
+++ b/angebotsdb/views/indexView.py
@@ -108,4 +108,6 @@ def save_dashboard_layout(request):
     return JsonResponse({'status': 'success'})
   except Exception as e:
     logger.error(f'Error saving dashboard layout: {e}')
-    return JsonResponse({'status': 'error', 'message': 'Ein interner Fehler ist aufgetreten.'}, status=400)
+    return JsonResponse(
+      {'status': 'error', 'message': 'Ein interner Fehler ist aufgetreten.'}, status=400
+    )

--- a/angebotsdb/views/indexView.py
+++ b/angebotsdb/views/indexView.py
@@ -108,4 +108,4 @@ def save_dashboard_layout(request):
     return JsonResponse({'status': 'success'})
   except Exception as e:
     logger.error(f'Error saving dashboard layout: {e}')
-    return JsonResponse({'status': 'error', 'message': str(e)}, status=400)
+    return JsonResponse({'status': 'error', 'message': 'Ein interner Fehler ist aufgetreten.'}, status=400)

--- a/linting/stylelint
+++ b/linting/stylelint
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 
 echo "Checking CSS rules via Stylelint..."
-node_modules/.bin/stylelint "datenwerft/**/*.css" "datenmanagement/**/*.css" "angebotsdb/**/*.css"
+node_modules/.bin/stylelint "datenwerft/**/*.css" "angebotsdb/**/*.css" "datenmanagement/**/*.css"


### PR DESCRIPTION
Use httpx and Django cache for PyGeoAPI label maps (10 minutes TTL). Introduce _fetch_pygeoapi_label_map and reuse it in fields and a template
tag to avoid duplicate fetches.
Add a reusable confirm modal (showConfirmModal) and hook it up in the service form: logo preview/delete and existing image deletion now use the modal instead of native confirm()