### PR TITLE
Cleanup provider and service image files on delete

### DIFF
--- a/angebotsdb/apps.py
+++ b/angebotsdb/apps.py
@@ -7,3 +7,6 @@ class AngebotsDBConfig(AppConfig):
   verbose_name = 'Angebotsdatenbank'
   description = 'Angebotsdatenbank'
   datenwerft_app = True
+
+  def ready(self):
+    from . import signals  # noqa: F401

--- a/angebotsdb/signals.py
+++ b/angebotsdb/signals.py
@@ -1,0 +1,38 @@
+from django.db.models.signals import post_delete, pre_save
+from django.dispatch import receiver
+
+from .models.base import Provider
+from .models.services import ServiceImage
+
+
+@receiver(pre_save, sender=Provider)
+def delete_old_logo_on_change(sender, instance, **kwargs):
+  if not instance.pk:
+    return
+  try:
+    old_logo = Provider.objects.get(pk=instance.pk).logo
+  except Provider.DoesNotExist:
+    return
+  new_logo = instance.logo
+  if old_logo and old_logo != new_logo:
+    old_logo.delete(save=False)
+
+
+@receiver(post_delete, sender=Provider)
+def delete_logo_on_provider_delete(sender, instance, **kwargs):
+  if instance.logo:
+    instance.logo.delete(save=False)
+
+
+@receiver(post_delete, sender=ServiceImage)
+def delete_file_on_serviceimage_delete(sender, instance, **kwargs):
+  # Draft-Copies teilen sich die Dateipfade (siehe utils.create_draft_copy),
+  # daher Datei nur löschen, wenn kein anderer Eintrag sie noch referenziert.
+  if not instance.image:
+    return
+  name = instance.image.name
+  still_referenced = (
+    ServiceImage.objects.filter(image=name).exclude(pk=instance.pk).exists()
+  )
+  if not still_referenced:
+    instance.image.delete(save=False)

--- a/angebotsdb/templates/angebotsdb/form.html
+++ b/angebotsdb/templates/angebotsdb/form.html
@@ -196,6 +196,9 @@
                       </div>
                     {% elif field.name == 'logo' %}
                       {% if form.instance.logo %}
+                        {% if user_can_save and not readonly %}
+                          <input type="hidden" name="{{ field.html_name }}-clear" id="logo-clear-input" value="">
+                        {% endif %}
                         <div class="d-flex align-items-center mb-2" id="logo-preview-row">
                           <a href="{{ form.instance.logo.url }}" target="_blank" class="me-2 flex-shrink-0">
                             <img src="{{ form.instance.logo.url }}" alt="Logo"
@@ -203,7 +206,6 @@
                           </a>
                           <span class="me-auto">{{ form.instance.logo.name|cut:"angebotsdb/hosts/" }}</span>
                           {% if user_can_save and not readonly %}
-                            <input type="hidden" name="{{ field.html_name }}-clear" id="logo-clear-input" value="">
                             <button type="button" class="btn btn-sm btn-outline-danger ms-2"
                                     id="logo-delete-btn">
                               <i class="fa-solid fa-xmark"></i>


### PR DESCRIPTION
Add model signals to remove obsolete media for Provider and ServiceImage.
Register the signals in AngebotsDBConfig.ready. Provider pre_save removes
old logos on change; Provider post_delete removes logos on provider deletion. ServiceImage post_delete deletes the file only if no other ServiceImage still references it. Also adjust the provider form to expose
a conditional hidden clear input when editing.