### PR TITLE
fix: Cache GitHub API calls and handle 3D model errors

### DIFF
--- a/datenmanagement/models/models_codelist.py
+++ b/datenmanagement/models/models_codelist.py
@@ -2649,9 +2649,7 @@ class Typen_Abfallbehaelter(Typ):
 
   class BasemodelMeta(Typ.BasemodelMeta):
     description = 'Typen von Abfallbehältern'
-    git_repo_of_3d_models = (
-      'https://github.com/rostock/3DModels/tree/main/Thumbnails/Abfallbehaelter'
-    )
+    git_repo_of_3d_models = 'https://github.com/rostock/3DModels/tree/main/Abfallbehaelter/thumbs'
 
 
 class Typen_Erdwaermesonden(Typ):

--- a/datenmanagement/templates/datenmanagement/form-list.html
+++ b/datenmanagement/templates/datenmanagement/form-list.html
@@ -86,6 +86,13 @@
                             {% endfor %}
                           </fieldset>
                         {% endif %}
+                        {% if thumb_urls_3d_models_unreachable and field.name == "model_3d" %}
+                          <div class="alert alert-warning mt-2 mb-0" role="alert">
+                            <i class="fa-solid fa-triangle-exclamation"></i>
+                            Die 3D-Modell-Galerie konnte momentan nicht aus dem GitHub-Repository geladen werden.
+                            Sie können den Modellnamen vorübergehend manuell eintragen oder es später erneut versuchen.
+                          </div>
+                        {% endif %}
                       {% endif %}
                     </td>
                   {% endautoescape %}
@@ -127,12 +134,12 @@
                 }
 
                 /**
-                 * remove jpg file extensions and replace underscores
+                 * replace underscores in displayed model names
                  */
                 function manipulate3DModelNames() {
                   const labels = document.querySelectorAll(".model-option > label > p")
                   labels.forEach(label => {
-                    label.textContent = label.textContent.replace(/\.jpg$/, '').replace(/_/g, ' ');
+                    label.textContent = label.textContent.replace(/_/g, ' ');
                   });
                 }
 
@@ -151,19 +158,22 @@
                 }
 
                 /**
-                 * update the original Input Field of 3D Model Selection
+                 * update the original Input Field of 3D Model Selection;
+                 * enforce exclusive selection across the radio group
                  */
                 function toggleRadioButton(radioId, event) {
-                  event.preventDefault(); // Verhindert das Standard-Verhalten
+                  event.preventDefault();
                   const radioButton = document.getElementById(radioId);
                   const inputField = document.getElementById('id_model_3d');
+                  const wasChecked = radioButton.checked;
 
-                  if (radioButton.checked) {
-                    // Radio button was already checked, uncheck it and clear input field
-                    radioButton.checked = false;
+                  document.querySelectorAll('input[name="model-selection"]').forEach(function (r) {
+                    r.checked = false;
+                  });
+
+                  if (wasChecked) {
                     inputField.value = '';
                   } else {
-                    // Radio button was not checked, check it and set input field value
                     radioButton.checked = true;
                     inputField.value = radioButton.value;
                   }

--- a/datenmanagement/views/functions.py
+++ b/datenmanagement/views/functions.py
@@ -1,4 +1,5 @@
 from decimal import Decimal
+from hashlib import sha256
 from json import JSONEncoder
 from pathlib import Path
 from re import IGNORECASE, search, sub
@@ -7,6 +8,7 @@ from wsgiref.util import FileWrapper
 
 from django.apps import apps
 from django.conf import settings
+from django.core.cache import cache
 from django.core.exceptions import PermissionDenied
 from django.db.models.fields import (
   DateField,
@@ -332,12 +334,22 @@ def generate_restricted_objects_list(restricted_objects):
   return '<ul>' + object_list + '</ul>' if len(restricted_objects) > 1 else object_list
 
 
+GITHUB_FILES_CACHE_TTL = 3600
+GITHUB_FILES_STALE_TTL = 86400
+
+
 def get_github_files(
   github_folder_url: str,
   file_filters: list[str] | dict[str, list[str]] | None = None,
-) -> dict[str, str]:
+  strip_extension: bool = False,
+) -> dict[str, str] | None:
   r"""
   Extrahiert Download-Links für Dateien aus einem GitHub-Unterverzeichnis mit flexibler Filterung.
+
+  Ergebnisse werden für ``GITHUB_FILES_CACHE_TTL`` Sekunden gecacht;
+  zusätzlich wird ein Stale-Wert für ``GITHUB_FILES_STALE_TTL`` Sekunden vorgehalten,
+  der bei einem fehlgeschlagenen API-Call als Fallback zurückgegeben wird.
+
   :param github_folder_url: Github Repo URL to specific folder
   :param file_filters: filters for filenames
   :type file_filters: list[str] | dict[str, list[str]] | None
@@ -348,25 +360,11 @@ def get_github_files(
       - 'patterns': list[str] - list of regex-patterns
       - 'prefixes': list[str] - list of prefixes
       - 'suffixes': list[str] - list of suffixes (incl. filetypes)
-  Returns:
-    dict: Dictionary mit Dateinamen als Keys und Download-URLs als Values
-  Examples:
-    # Alle Dateien holen
-    files = get_github_files("https://github.com/user/repo/tree/main/folder")
-    # Nur Bilder holen
-    image_files = get_github_files(
-      "https://github.com/user/repo/tree/main/folder",
-      ['.jpg', '.jpeg', '.png', '.gif', '.bmp', '.webp']
-    )
-    # Komplexe Filterung
-    filtered_files = get_github_files(
-      "https://github.com/user/repo/tree/main/folder",
-      {
-        'patterns': [r'protokoll_\d{4}'],
-        'prefixes': ['rostock_'],
-        'suffixes': ['_final.pdf']
-      }
-    )
+  :param strip_extension: wenn True, Dateiendung im Result-Key entfernen
+    (z.B. ``Dinova.jpg`` → ``Dinova``)
+  :returns:
+    - ``dict[str, str]`` (Dateiname → Download-URL) bei Erfolg, auch leer.
+    - ``None`` bei Netzwerk-/HTTP-Fehler, sofern kein Stale-Wert verfügbar ist.
   """
   # Konvertiere normale GitHub-URL in API-URL
   parsed = urlparse(github_folder_url)
@@ -381,31 +379,34 @@ def get_github_files(
   # Erstelle API-URL
   api_url = f'https://api.github.com/repos/{owner}/{repo}/contents/{folder_path}?ref={branch}'
 
+  # Cache-Key aus Aufrufparametern ableiten
+  cache_key_payload = f'{api_url}|{file_filters!r}|{strip_extension}'
+  cache_key = f'gh_files:{sha256(cache_key_payload.encode()).hexdigest()}'
+  stale_key = f'{cache_key}:stale'
+
+  cached = cache.get(cache_key)
+  if cached is not None:
+    return cached
+
   def matches_filters(filename: str) -> bool:
     """Prüft, ob ein Dateiname die Filter-Kriterien erfüllt."""
-    # Wenn keine Filter definiert sind, geben wir alle Dateien zurück
     if file_filters is None:
       return True
 
-    # Wenn file_filters eine Liste ist, behandeln wir sie als Dateiendungen
     if isinstance(file_filters, list):
       return any(filename.lower().endswith(ext.lower()) for ext in file_filters)
 
-    # Komplexe Filterung mit Dictionary
     if isinstance(file_filters, dict):
-      # Prüfe Regex-Patterns
       if 'patterns' in file_filters:
         if not any(search(pattern, filename, IGNORECASE) for pattern in file_filters['patterns']):
           return False
 
-      # Prüfe Präfixe
       if 'prefixes' in file_filters:
         if not any(
           filename.lower().startswith(prefix.lower()) for prefix in file_filters['prefixes']
         ):
           return False
 
-      # Prüfe Suffixe
       if 'suffixes' in file_filters:
         if not any(
           filename.lower().endswith(suffix.lower()) for suffix in file_filters['suffixes']
@@ -415,28 +416,34 @@ def get_github_files(
       return True
     return False
 
-  try:
-    # API-Anfrage senden
-    response = get(url=api_url)
+  def make_key(filename: str) -> str:
+    if not strip_extension:
+      return filename
+    dot = filename.rfind('.')
+    return filename[:dot] if dot > 0 else filename
 
-    # handle response
+  try:
+    response = get(url=api_url, timeout=5.0)
+
     if response.status_code < 200 or response.status_code >= 300:
-      logger.error(f'Network error: {response.status_code} - {response.reason_phrase}')
-      return {}
+      logger.error(f'GitHub API error: {response.status_code} - {response.reason_phrase}')
+      stale = cache.get(stale_key)
+      return stale if stale is not None else None
 
     files = response.json()
-    print(files)
     file_links = {}
-
     for file in files:
       if file['type'] == 'file' and matches_filters(file['name']):
-        file_links[file['name']] = file['download_url']
+        file_links[make_key(file['name'])] = file['download_url']
 
+    cache.set(cache_key, file_links, GITHUB_FILES_CACHE_TTL)
+    cache.set(stale_key, file_links, GITHUB_FILES_STALE_TTL)
     return file_links
 
   except Exception as e:
-    print(f'Error retrieving data: {e}')
-    return {}
+    logger.error(f'Error retrieving data from GitHub: {e}')
+    stale = cache.get(stale_key)
+    return stale if stale is not None else None
 
 
 def get_model_objects(model, subset_id=None, count_only=False):

--- a/datenmanagement/views/views_form.py
+++ b/datenmanagement/views/views_form.py
@@ -102,9 +102,16 @@ class DataAddView(CreateView):
     referer = self.request.META['HTTP_REFERER'] if 'HTTP_REFERER' in self.request.META else None
     context['url_back'] = get_url_back(referer, 'datenmanagement:' + model_name + '_start')
     if self.model.BasemodelMeta.git_repo_of_3d_models:
-      context['thumb_urls_3d_models'] = get_github_files(
-        self.model.BasemodelMeta.git_repo_of_3d_models
+      thumbs = get_github_files(
+        self.model.BasemodelMeta.git_repo_of_3d_models,
+        ['.jpg', '.jpeg', '.png', '.webp'],
+        strip_extension=True,
       )
+      if thumbs is None:
+        context['thumb_urls_3d_models'] = {}
+        context['thumb_urls_3d_models_unreachable'] = True
+      else:
+        context['thumb_urls_3d_models'] = thumbs
     return context
 
   def get_initial(self):
@@ -365,9 +372,16 @@ class DataChangeView(D3ContextMixin, UpdateView):
       elif field_name_for_address_type == 'district' and self.object.gemeindeteil:
         context['current_' + field_name_for_address_type] = self.object.gemeindeteil.pk
     if self.model.BasemodelMeta.git_repo_of_3d_models:
-      context['thumb_urls_3d_models'] = get_github_files(
-        self.model.BasemodelMeta.git_repo_of_3d_models
+      thumbs = get_github_files(
+        self.model.BasemodelMeta.git_repo_of_3d_models,
+        ['.jpg', '.jpeg', '.png', '.webp'],
+        strip_extension=True,
       )
+      if thumbs is None:
+        context['thumb_urls_3d_models'] = {}
+        context['thumb_urls_3d_models_unreachable'] = True
+      else:
+        context['thumb_urls_3d_models'] = thumbs
     # prepare a dictionary for all array fields and their contents that contain more than one value
     array_fields_values = {}
     for field in self.model._meta.get_fields():


### PR DESCRIPTION
Implements stale-while-revalidate caching for GitHub file lookups. Shows a warning alert in the form when the 3D model gallery is unreachable. Strips file extensions server-side and fixes radio button toggle behavior.