### PR TITLE
Use semantic Bootstrap classes for theme support

### DIFF
--- a/angebotsdb/static/angebotsdb/css/dashboard.css
+++ b/angebotsdb/static/angebotsdb/css/dashboard.css
@@ -7,7 +7,7 @@
 }
 
 .grid-item {
-  background-color: lightgoldenrodyellow;
+  background-color: transparent;
   place-self: stretch stretch;
   transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
   position: relative;

--- a/bemas/templates/bemas/index.html
+++ b/bemas/templates/bemas/index.html
@@ -19,7 +19,7 @@
           </div>
         </div>
         <div class="col-8">
-          <div class="card bg-light h-100">
+          <div class="card bg-body-secondary h-100">
             <div class="card-header"><i class="me-2 fa-solid fa-{{ 'activity'|get_icon }}"></i>letzte Aktivitäten</div>
             <div class="card-body">
               <table class="table table-borderless small mb0">
@@ -105,7 +105,7 @@
       </div>
       <div class="mt-1 mb-3 row g-4">
         <div class="col-8">
-          <div class="card bg-light h-100">
+          <div class="card bg-body-secondary h-100">
             <div class="card-header"><i class="fa-solid fa-{{ 'statistics'|get_icon }}"></i> Statistiken</div>
             <div class="card-body{% if not statistics %} text-center{% endif %}">
               {% if statistics %}

--- a/datenwerft/templates/index.html
+++ b/datenwerft/templates/index.html
@@ -6,7 +6,7 @@
 {% block content %}
   <div class="container-xxl">
   {% if user.is_authenticated %}
-    <a class="text-black" data-bs-toggle="collapse" href="#yourApps" aria-expanded="true" aria-controls="yourApps">
+    <a class="text-body" data-bs-toggle="collapse" href="#yourApps" aria-expanded="true" aria-controls="yourApps">
       <h1 class="mb-4">
         <i class="fa-fw fa-solid fa-angle-down" id="caretIconYourApps"></i>
         Apps
@@ -15,7 +15,7 @@
     <div class="row row-cols-1 row-cols-md-2 row-cols-lg-2 row-cols-xl-3 g-4 text-center mb-5 collapse show" id="yourApps">
       {% for app in apps %}
         <div class="col">
-          <div class="card h-100 bg-primary-subtle border-primary rounded text-black">
+          <div class="card h-100 bg-primary-subtle border-primary rounded text-body">
             <div class="card-header bg-primary-subtle border-primary">
               <h2>{{ app.verbose_name }}</h2>
             </div>
@@ -46,7 +46,7 @@
       });
     </script>
     {% if user.is_staff %}
-      <a class="text-black" data-bs-toggle="collapse" href="#admin-apps" aria-expanded="false" aria-controls="admin-apps">
+      <a class="text-body" data-bs-toggle="collapse" href="#admin-apps" aria-expanded="false" aria-controls="admin-apps">
         <h1 class="mb-4">
           <i class="fa-fw fa-solid fa-angle-right" id="caretIconAdminApps"></i>
           Admin-Apps
@@ -55,7 +55,7 @@
       <div class="row row-cols-1 row-cols-md-2 row-cols-lg-2 row-cols-xl-3 g-4 text-center mb-5 collapse" id="admin-apps">
         {% for app in admin_apps %}
           <div class="col">
-            <div class="card h-100 bg-danger-subtle border-danger rounded text-black">
+            <div class="card h-100 bg-danger-subtle border-danger rounded text-body">
               <div class="card-header bg-danger-subtle border-danger">
                 <h2>{{ app.name }}</h2>
               </div>

--- a/fmm/templates/fmm/index.html
+++ b/fmm/templates/fmm/index.html
@@ -20,7 +20,7 @@
           </div>
         </div>
         <div class="col-8">
-          <div class="card bg-light h-100">
+          <div class="card bg-body-secondary h-100">
             <div class="card-header"><i class="me-2 fa-solid fa-{{ 'activity'|get_icon }}"></i>letzte Änderungen an FMF</div>
             <div class="card-body">
               <table class="table table-borderless small mb0">


### PR DESCRIPTION
Replace hardcoded colors (text-black, bg-light, lightgoldenrodyellow) with theme-aware alternatives (text-body, bg-body-secondary, transparent)
to improve dark mode compatibility.