### PR TITLE
fixed status toggling (i.e. showing or hiding) of Bootstrap modals in all apps

### DIFF
--- a/antragsmanagement/templates/antragsmanagement/table_request.html
+++ b/antragsmanagement/templates/antragsmanagement/table_request.html
@@ -78,7 +78,7 @@
           });
           fetchRequestCommentList($(this).data('list-url'));
           // open corresponding modal
-          toggleModal($('#request-comment-list-modal'));
+          $('#request-comment-list-modal').modal('show');
         });
 
         /**

--- a/bemas/static/bemas/js/form.js
+++ b/bemas/static/bemas/js/form.js
@@ -62,12 +62,14 @@ function adoptReverseSearchResult(geoJson) {
       return false;
     }
   });
-  if (erfolg === false)
-    toggleModal(
+  if (erfolg === false) {
+    setModal(
       $('#error-modal'),
       'Keine automatische Zuordnung einer Adresse möglich!',
       'Bitte setzen Sie den Marker in der Karte ' + window.reverseSearchRadius + ' m oder dichter an die nächste Adresse heran.'
     );
+    $('#error-modal').modal('show');
+  }
 }
 
 /**

--- a/bemas/static/bemas/js/map.js
+++ b/bemas/static/bemas/js/map.js
@@ -56,14 +56,19 @@ function createFilterObject(name, type, value) {
  */
 async function fetchGeoJsonFeatureCollection(url, lastCall=false) {
   try {
-    if (lastCall === false || lastCall === null)
-      toggleModal($('#loading-modal'), 'Laden der Kartendaten', 'Die Kartendaten werden (nach-)geladen.');
+    if (lastCall === false || lastCall === null) {
+      setModal($('#loading-modal'), 'Laden der Kartendaten', 'Die Kartendaten werden (nach-)geladen.');
+      $('#loading-modal').modal('show');
+    }
     const response = await fetch(url, {
       method: 'GET'
     });
     const data = await response.json();
-    if (lastCall === true || lastCall === null)
-      toggleModal($('#loading-modal'));
+    if (lastCall === true || lastCall === null) {
+      setTimeout(() => {
+        $('#loading-modal').modal('hide');
+      }, 1000);
+    }
     return data;
   } catch (error) {
     console.error(error);

--- a/datenmanagement/static/datenmanagement/js/form.js
+++ b/datenmanagement/static/datenmanagement/js/form.js
@@ -66,12 +66,14 @@ function adoptReverseSearchResult(geoJson, addressType) {
       return false;
     }
   });
-  if (erfolg === false)
-    toggleModal(
+  if (erfolg === false) {
+    setModal(
       $('#error-modal'),
       'Keine automatische Zuordnung ' + (addressType === 'Gemeindeteil' ? 'eines ' : 'einer ') + addressType + (addressType === 'Gemeindeteil' ? 's' : '') + ' möglich!',
       'Bitte setzen Sie den Marker bzw. zeichnen Sie die Linie oder Fläche in der Karte ' + window.reverseSearchRadius + ' m oder dichter an ' + (addressType === 'Gemeindeteil' ? 'den nächsten ' : 'die nächste ') + addressType +  ' heran.'
     );
+    $('#error-modal').modal('show');
+  }
 }
 
 /**

--- a/datenmanagement/static/datenmanagement/js/genericHelpers.js
+++ b/datenmanagement/static/datenmanagement/js/genericHelpers.js
@@ -82,19 +82,18 @@ function refreshModal(modal, title = '', body = '', addFooter = false) {
 
 /**
  * @function
- * @name toggleModal
+ * @name setModal
  *
- * toggles visibility of passed Bootstrap modal
+ * sets title, body, and additional content of passed Bootstrap modal
  *
  * @param {Object} modal - Bootstrap modal
  * @param {string} [title=''] - titel of the Bootstrap modal
  * @param {string} [body=''] - body of the Bootstrap modal
- * @param {string} [customLoadingContent=null] - additional content for loading view
+ * @param {string} [customLoadingContent=''] - additional content for loading view
  */
-function toggleModal(modal, title = '', body = '', customLoadingContent = '') {
+function setModal(modal, title = '', body = '', customLoadingContent = '') {
   if (title || body)
     refreshModal(modal, title, body);
   if (customLoadingContent)
     modal.find(customLoadingContent).prop('hidden', false);
-  modal.modal('toggle');
 }

--- a/datenmanagement/static/datenmanagement/js/leafletHelpers.js
+++ b/datenmanagement/static/datenmanagement/js/leafletHelpers.js
@@ -412,19 +412,21 @@ L.Map.prototype.updateMap = function(layerControl, isWFS = false) {
       let zoomDifference = minZoom - this.getZoom() + 1;
       zoomDifference += zoomDifference === 1 ? ' Stufe' : ' Stufen';
       if (isWFS === true && window.showWFSZoomModal === true) {
-        toggleModal(
+        setModal(
           $('#error-modal'),
           'Sichtbarkeit zusätzlicher WFS-Feature-Types',
           'Sie müssen zunächst ' + zoomDifference + ' in die Karte hineinzoomen, bevor die zusätzlichen WFS-Feature-Types wieder sichtbar werden!'
         );
+        $('#error-modal').modal('show');
         window.showWFSZoomModal = false;
       }
       if (isWFS === false && window.showDataThemesZoomModal === true) {
-        toggleModal(
+        setModal(
           $('#error-modal'),
           'Sichtbarkeit zusätzlicher Datenthemen',
           'Sie müssen zunächst ' + zoomDifference + ' in die Karte hineinzoomen, bevor die zusätzlichen Datenthemen wieder sichtbar werden!'
         );
+        $('#error-modal').modal('show');
         window.showDataThemesZoomModal = false;
       }
       this.eachLayer((layer) => {

--- a/datenmanagement/static/datenmanagement/js/map.js
+++ b/datenmanagement/static/datenmanagement/js/map.js
@@ -43,12 +43,13 @@ async function fetchGeoJsonFeatureCollection(heavyLoad = false, limit = 0, offse
     if (heavyLoad) {
       url += '?limit=' + limit + '&offset=' + offset;
     }
-    toggleModal(
+    setModal(
       $('#loading-modal'),
       'Laden der Kartendaten',
       'Die Kartendaten werden (nach-)geladen.' + (heavyLoad ? ' Dies kann einen Moment dauern, da es sich insgesamt um eine sehr große Datenmenge handelt.' : ''),
-      heavyLoad ? '#loading-modal-map-data' : null
+      heavyLoad ? '#loading-modal-map-data' : ''
     );
+    $('#loading-modal').modal('show');
     const response = await fetch(url, {
       method: 'GET'
     });
@@ -56,11 +57,14 @@ async function fetchGeoJsonFeatureCollection(heavyLoad = false, limit = 0, offse
     if (heavyLoad) {
       window.count += data.features.length;
       $('#loading-modal-map-data-count').text(window.count);
-      if (window.count === window.border)
-        $('#loading-modal-close').click();
+      if (window.count === window.border) {
+        setTimeout(() => {
+          $('#loading-modal').modal('hide');
+        }, 1000);
+      }
     } else {
-      setTimeout(function () {
-        $('#loading-modal-close').click();
+      setTimeout(() => {
+        $('#loading-modal').modal('hide');
       }, 1000);
     }
     return data;

--- a/datenmanagement/static/datenmanagement/js/subsetting.js
+++ b/datenmanagement/static/datenmanagement/js/subsetting.js
@@ -35,17 +35,19 @@ function subsetting(keys, subsetURL, modelName, modelPrimaryKeyField, successURL
     .catch(
       (error) => {
         console.error(error);
-        toggleModal(
+        setModal(
           $('#error-modal'),
           errorModalTitle,
           errorText ? errorText : 'Bei der Übernahme der aktuellen Filtermenge ist ein Serverfehler aufgetreten.'
         );
+        $('#error-modal').modal('show');
       }
     );
   } else
-    toggleModal(
+    setModal(
       $('#error-modal'),
       errorModalTitle,
       'Die aktuelle Filtermenge ist leer.'
     );
+    $('#error-modal').modal('show');
 }

--- a/datenmanagement/templates/datenmanagement/form-map.html
+++ b/datenmanagement/templates/datenmanagement/form-map.html
@@ -239,11 +239,12 @@
                         } else if (window.showDataThemesZoomModal === true) {
                           let zoomDifference = map._minLayerZoomForDataThemes - map.getZoom() + 1;
                           zoomDifference += zoomDifference === 1 ? ' Stufe' : ' Stufen';
-                          toggleModal(
+                          setModal(
                             $('#error-modal'),
                             'Sichtbarkeit zusätzlicher Datenthemen',
                             'Sie müssen zunächst ' + zoomDifference + ' in die Karte hineinzoomen, bevor die zusätzlichen Datenthemen sichtbar werden!'
                           );
+                          $('#error-modal').modal('show');
                           window.showDataThemesZoomModal = false;
                         }
                       });
@@ -307,11 +308,12 @@
                       } else if (window.showWFSZoomModal === true) {
                         let zoomDifference = map._minLayerZoomForWFSFeaturetypes - map.getZoom() + 1;
                         zoomDifference += zoomDifference === 1 ? ' Stufe' : ' Stufen';
-                        toggleModal(
+                        setModal(
                           $('#error-modal'),
                           'Sichtbarkeit zusätzlicher WFS-Feature-Types',
                           'Sie müssen zunächst ' + zoomDifference + ' in die Karte hineinzoomen, bevor die zusätzlichen WFS-Feature-Types sichtbar werden!'
                         );
+                        $('#error-modal').modal('show');
                         window.showWFSZoomModal = false;
                       }
                     });
@@ -714,11 +716,12 @@
                   modeName = 'GPX';
                 {% endif %}
                 $('#id_' + mode).change(function (e) {
-                  toggleModal(
+                  setModal(
                     $('#loading-modal'),
                     'Auswerten der ' + modeName + '-Datei',
                     'Die ' + modeName + '-Datei wird zum Server hochgeladen und ausgewertet. Dies kann einen Moment dauern.'
                   );
+                  $('#loading-modal').modal('show');
                   let file = e.target.files[0];
                   let formData = new FormData();
                   formData.append(mode, file);
@@ -765,7 +768,6 @@
                         // set map extent to bounding box of GeoJSON layer group
                         setMapExtentByLeafletBounds(geojsonLayer.getBounds());
                       }
-                      toggleModal($('#loading-modal'));
                     }
                   ).catch(
                     (error) => {
@@ -776,6 +778,12 @@
                         true
                       );
                       console.error(error);
+                    }
+                  ).finally(
+                    () => {
+                      setTimeout(() => {
+                        $('#loading-modal').modal('hide');
+                      }, 1000);
                     }
                   );
                 });
@@ -810,11 +818,12 @@
                   ).catch(
                     (error) => {
                       console.error(error);
-                      toggleModal(
+                      setModal(
                         $('#error-modal'),
                         'Fehler bei Zuweisung einer Postleitzahl',
                         'Es ist ein Fehler bei der automatischen Zuweisung einer Postleitzahl aufgetreten. Bitte versuchen Sie es erneut oder kontaktieren Sie einen Administrator.'
                       );
+                      $('#error-modal').modal('show');
                     }
                   );
                 });

--- a/datenmanagement/templates/datenmanagement/list.html
+++ b/datenmanagement/templates/datenmanagement/list.html
@@ -185,8 +185,9 @@
             // if selected action is assigning a specific value to a specific field of all selected rows (= records)...
             if ($('#action-select').val().startsWith('assign-selected-')) {
               // get name of corresponding modal and open it
-              let modalName = $('#action-select').val().replace('assign-selected-', '');
-              toggleModal($('#action-assign-' + modalName + '-modal'));
+              const modalName = $('#action-select').val().replace('assign-selected-', '');
+              setModal($('#action-assign-' + modalName + '-modal'));
+              $('#action-assign-' + modalName + '-modal').modal('show');
               // execute the assignment action on clicking the "OK" button in the assignment action modal...
               $('#action-assign-' + modalName + '-modal-ok').on('click', function() {
                 let field = $('#action-assign-' + modalName + '-modal-input-field');
@@ -199,7 +200,7 @@
                     jQuery.get(url + '?field=' + field.attr('name') + '&value=' + field.val());
                   });
                   // close corresponding modal
-                  toggleModal($('#action-assign-' + modalName + '-modal'));
+                  $('#action-assign-' + modalName + '-modal').modal('hide');
                   // wait briefly and reload the table so that row (= record) changes become visible
                   reloadDataTable(table);
                 // otherwise, show hint on required form data
@@ -210,7 +211,8 @@
             // if selected action is deleting all selected rows (= records)...
             } else if ($('#action-select').val() === 'delete-selected') {
               // open corresponding modal
-              toggleModal($('#action-delete-modal'));
+              setModal($('#action-delete-modal'));
+              $('#action-delete-modal').modal('show');
               // execute the deletion action on clicking the "OK" button in the deletion action modal...
               $('#action-delete-modal-ok').on('click', function() {
                 // go through all selected rows (= records)...
@@ -219,7 +221,7 @@
                   jQuery.get('{{ url_model_deleteimmediately_placeholder }}'.replace(/worschdsupp/, $(this).val().toString()));
                 });
                 // close corresponding modal
-                toggleModal($('#action-delete-modal'));
+                $('#action-delete-modal').modal('hide');
                 // wait briefly and reload the table so that deleted rows (= records) disappear
                 reloadDataTable(table);
               });
@@ -270,8 +272,9 @@
             });
             fetchPdf('{% url "toolbox:renderpdf" %}', '{{ csrf_token }}', '{{ request.get_host }}');
           }
-          else
-            toggleModal($('#confirm-export-modal'));
+          else {
+            $('#confirm-export-modal').modal('show');
+          }
         });
 
         // select or unselect all rows (= records)
@@ -305,7 +308,7 @@
           $('#action-select option[value="delete-selected"]').text('ausgewählte Datensätze löschen');
           $('#action-delete-modal-title').text('Ausgewählte Datensätze löschen?');
           $('#action-delete-modal-body').html('');
-          $('#action-delete-modal-body').append('<p>Sie haben ' + actionCheckboxes.length + ' ' + 'Datensätze ausgewählt. Sollen diese wirklich gelöscht werden?</p>');
+          $('#action-delete-modal-body').append('<p>Sie haben ' + actionCheckboxes.length + ' Datensätze ausgewählt. Sollen diese wirklich gelöscht werden?</p>');
         }
       });
     </script>

--- a/datenwerft/static/js/form.js
+++ b/datenwerft/static/js/form.js
@@ -62,12 +62,14 @@ function adoptReverseSearchResult(geoJson) {
       return false;
     }
   });
-  if (erfolg === false)
-    toggleModal(
+  if (erfolg === false) {
+    setModal(
       $('#error-modal'),
       'Keine automatische Zuordnung einer Adresse möglich!',
       'Bitte setzen Sie den Marker in der Karte ' + window.reverseSearchRadius + ' m oder dichter an die nächste Adresse heran.'
     );
+    $('#error-modal').modal('show');
+  }
 }
 
 /**

--- a/stadtbereichskatalog/static/stadtbereichskatalog/js/dataImportMapping.js
+++ b/stadtbereichskatalog/static/stadtbereichskatalog/js/dataImportMapping.js
@@ -51,11 +51,12 @@ $(document).ready(function() {
   $('#upload-file').on('click', async function() {
     const fileInput = $('#file-input')[0];
     if (!fileInput.files.length) {
-      toggleModal(
+      setModal(
         $('#messages-modal'),
         `<i class="fa-solid ${ICON_WARNING} text-warning"></i> Quelldatei fehlt`,
         'Bitte wählen Sie zunächst eine Quelldatei für den Upload aus.'
       );
+      $('#messages-modal').modal('show');
       return;
     }
     const file = fileInput.files[0];

--- a/stadtbereichskatalog/static/stadtbereichskatalog/js/functions.js
+++ b/stadtbereichskatalog/static/stadtbereichskatalog/js/functions.js
@@ -538,7 +538,8 @@ function renderImportResult(result) {
       body = 'Beim Importieren ist ein Fehler aufgetreten.';
     }
   }
-  toggleModal($('#messages-modal'), title, body);
+  setModal($('#messages-modal'), title, body);
+  $('#messages-modal').modal('show');
 }
 
 
@@ -692,7 +693,8 @@ function buildDataExportURL(baseURL) {
 function showDataExportModal(fileType) {
   let title = `<i class="fa-solid ${ICON_SUCCESS} text-success"></i> Export erfolgreich`;
   let body = `Im Hintergrund wurde eine ${fileType} erzeugt und direkt von Ihrem Browser heruntergeladen, sodass diese sich nunmehr im eingestellten Download-Ordner befindet.`;
-  toggleModal($('#messages-modal'), title, body);
+  setModal($('#messages-modal'), title, body);
+  $('#messages-modal').modal('show');
 }
 
 
@@ -741,7 +743,8 @@ function renderDeletionResult(result) {
       body = 'Beim Löschen ist ein Fehler aufgetreten.';
     }
   }
-  toggleModal($('#messages-modal'), title, body);
+  setModal($('#messages-modal'), title, body);
+  $('#messages-modal').modal('show');
 }
 
 
@@ -981,5 +984,6 @@ function renderupdateResult(result) {
       body = 'Beim Aktualisieren ist ein Fehler aufgetreten.';
     }
   }
-  toggleModal($('#messages-modal'), title, body);
+  setModal($('#messages-modal'), title, body);
+  $('#messages-modal').modal('show');
 }

--- a/stadtbereichskatalog/templates/stadtbereichskatalog/data_export.html
+++ b/stadtbereichskatalog/templates/stadtbereichskatalog/data_export.html
@@ -98,6 +98,7 @@
       const EXPORT_CSV_EXCEL_URL = "{% url app.name|add:':export_csv_excel' %}";
       const EXPORT_CSV_STANDARD_URL = "{% url app.name|add:':export_csv_standard' %}";
       const EXPORT_EXCEL_URL = "{% url app.name|add:':export_excel' %}";
+      const ICON_SUCCESS = "fa-{{ 'success'|get_icon }}";
     </script>
   {% else %}
     {% include "stadtbereichskatalog/notice_no-permissions.html" %}


### PR DESCRIPTION
Using the `toggle()` function to switch the state of a modal (i.e., showing it when hidden or hiding it again when visible) proved unstable, particularly in cases where both the _show_ and _hide_ events were triggered automatically. Consequently, the logic was rewritten to consistently use the `modal('show')` and `modal('hide')` functions.